### PR TITLE
Probes.to_pandas(): sort values before generating multi-index

### DIFF
--- a/SOWFA/postProcessing/probes.py
+++ b/SOWFA/postProcessing/probes.py
@@ -259,7 +259,7 @@ class Probe(object):
             df['z'] = self.pos[iprobe,2]
             dflist.append(df)
         #return pd.concat(dflist).set_index(['t','id'])
-        return pd.concat(dflist).set_index(['t','z'])
+        return pd.concat(dflist).sort_values(['t','z']).set_index(['t','z'])
 
     def to_csv(self,fname):
         self.to_pandas().to_csv(fname)


### PR DESCRIPTION
Output from `Probe(ref_probe_dpath).to_pandas().head()`.

I think having the last multi-index change the fastest is more efficient (e.g., for pivoting/unstacking), and this may be why you had issues slicing and plotting multi-indices in the past.


Before:

  |   | Ux | Uy | Uz | T
-- | -- | -- | -- | -- | --
20000.429738 | 406.001 | 3.016210 | -0.790004 | 0.338619 | 300.004871
20000.858308 | 406.001 | 4.497612 | -0.066623 | 0.368078 | 300.004859
20001.280228 | 406.001 | 4.625682 | 1.044923 | 0.490880 | 300.004850
20001.702149 | 406.001 | 5.889939 | 0.914651 | 0.322441 | 300.004960
20002.124667 | 406.001 | 6.895499 | 0.311255 | 0.047167 | 300.004763
... | ... | ... | ... | ... | ...

After:

  |   | Ux | Uy | Uz | T
-- | -- | -- | -- | -- | --
20000.429738 | 406.001 | 3.016210 | -0.790004 | 0.338619 | 300.004871
&nbsp; | 416.001 | 4.497612 | -0.066623 | 0.368078 | 300.004859
&nbsp; | 426.001 | 4.625682 | 1.044923 | 0.490880 | 300.004850
&nbsp; | 436.001 | 5.889939 | 0.914651 | 0.322441 | 300.004960
&nbsp; | 446.001 | 6.895499 | 0.311255 | 0.047167 | 300.004763
... | ... | ... | ... | ... | ...


